### PR TITLE
more consistent error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -363,6 +363,7 @@ dependencies = [
  "clap 2.31.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "evdev-rs 0.0.1 (git+https://github.com/ndesh26/evdev-rs?rev=c271060)",
  "jack 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "palette 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sdl 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,4 @@ evdev-rs = { git = "https://github.com/ndesh26/evdev-rs", rev = "c271060" }
 sdl = "*"
 palette = "*"
 clap = "*"
+nix = "*"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,6 +1,7 @@
 extern crate clap;
 
 use self::clap::{App, Arg};
+use ErrorString;
 use std::fmt::Display;
 use std::str::FromStr;
 
@@ -10,7 +11,7 @@ pub struct CliArgs {
     pub start_note: i32,
 }
 
-pub fn parse<'a, 'b>(app: App<'a, 'b>) -> Result<CliArgs, String> {
+pub fn parse<'a, 'b>(app: App<'a, 'b>) -> Result<CliArgs, ErrorString> {
     let matches = app.version("0.1.0")
         .author("Sönke Hahn <soenkehahn@gmail.com>")
         .about("musical instrument for touch screens")
@@ -34,13 +35,15 @@ pub fn parse<'a, 'b>(app: App<'a, 'b>) -> Result<CliArgs, String> {
     Ok(CliArgs { volume, start_note })
 }
 
-fn parse_with_default<N>(input: Option<&str>, default: N) -> Result<N, String>
+fn parse_with_default<N>(input: Option<&str>, default: N) -> Result<N, ErrorString>
 where
     N: FromStr,
     <N as FromStr>::Err: Display,
 {
     match input {
         None => Ok(default),
-        Some(string) => string.parse().map_err(|e| format!("{}", e)),
+        Some(string) => string
+            .parse()
+            .map_err(|e| ErrorString::from(format!("{}", e))),
     }
 }

--- a/src/evdev.rs
+++ b/src/evdev.rs
@@ -1,10 +1,10 @@
 extern crate evdev_rs;
 
-use AppError;
+use AddMessage;
+use ErrorString;
 use evdev::evdev_rs::enums::{EV_SYN::*, EventCode, EventType::*, EV_ABS};
 use evdev::evdev_rs::*;
 use std::fs::File;
-use to_app_error;
 
 pub struct Events {
     _file: File,
@@ -12,13 +12,12 @@ pub struct Events {
 }
 
 impl Events {
-    pub fn new(path: &str) -> Result<Events, AppError> {
-        let file =
-            File::open(path).map_err(|_| AppError::new(format!("file not found: {}", path)))?;
-        let mut device = to_app_error(Device::new(), "evdev: can't initialize device")?;
+    pub fn new(path: &str) -> Result<Events, ErrorString> {
+        let file = File::open(path).add_message(format!("file not found: {}", path))?;
+        let mut device = Device::new().ok_or("evdev: can't initialize device")?;
         device
             .set_fd(&file)
-            .map_err(|e| AppError::new(format!("set_fd failed on {} ({:?})", path, e)))?;
+            .add_message(format!("set_fd failed on {}", path))?;
         device.grab(GrabMode::Grab)?;
         Ok(Events {
             _file: file,
@@ -146,7 +145,7 @@ impl Positions {
         }
     }
 
-    pub fn new(file: &str) -> Result<Positions, AppError> {
+    pub fn new(file: &str) -> Result<Positions, ErrorString> {
         Ok(Positions::new_from_iterator(Events::new(file)?))
     }
 }


### PR DESCRIPTION
Currently I don't have the need for distinguishing between different error types in the code, so all errors just get converted to `ErrorString`, which is just a wrapper type around `String`.