### PR TITLE
enable formatting checks on CI again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,12 +6,17 @@ jobs:
       - image: rust:1.26.2-stretch
 
     steps:
+      - checkout
+      - run:
+          name: check formatting
+          command: |
+            rustup component add rustfmt-preview
+            cargo fmt -- --write-mode=diff
       - run:
           name: install dependencies
           command: |
             apt-get update &&
             apt-get install --yes libsdl2-dev libsdl2-gfx-dev libjack-jackd2-dev
-      - checkout
       - run:
           name: tests
           command: cargo test --features=ci

--- a/src/areas/mod.rs
+++ b/src/areas/mod.rs
@@ -142,8 +142,7 @@ impl Areas {
     }
 
     pub fn frequency(&self, position: Position) -> NoteEvent {
-        let touched: Option<&Area> = self
-            .areas
+        let touched: Option<&Area> = self.areas
             .iter()
             .filter(|area| area.shape.contains(position))
             .next();

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -16,8 +16,7 @@ pub struct Args {
 }
 
 pub fn parse<'a, 'b>(app: App<'a, 'b>) -> Result<Args, ErrorString> {
-    let matches = app
-        .version("0.1.0")
+    let matches = app.version("0.1.0")
         .author("Sönke Hahn <soenkehahn@gmail.com>")
         .about("musical instrument for touch screens")
         .arg(


### PR DESCRIPTION
This repo now uses rustfmt version 0.6.1-stable.

@caroline-lin: I figured out a way to install the stable `rustfmt` version:

- delete `~/.rustup`
- delete `~/.cargo`
- reinstall [rustup](https://rustup.rs/)
- run `rustup component add rustfmt-preview`

There's probably a better way, but this is the only way I know... :/ But at least we can have formatting checks back on CI.