### PR TITLE
update rustc version on CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: rust:1.26.2-stretch
+      - image: rust:1.27.0-stretch
 
     steps:
       - checkout


### PR DESCRIPTION
@caroline-lin: You can just do `rustup update` to get the newest version locally.