### PR TITLE
start jackd automatically

### DIFF
--- a/src/sound/audio_player.rs
+++ b/src/sound/audio_player.rs
@@ -23,7 +23,7 @@ impl AudioPlayer {
         F: Fn(f32) -> f32 + 'static + Send + Clone,
     {
         let name = get_binary_name()?;
-        let (client, _status) = jack::Client::new(&name, jack::ClientOptions::NO_START_SERVER)?;
+        let (client, _status) = jack::Client::new(&name, jack::ClientOptions::empty())?;
         let generators = slot_map(generator_args.unfold_generator_args(), |args| {
             Generator::new((*args).clone(), client.sample_rate() as i32)
         });


### PR DESCRIPTION
I think merging this does not have any disadvantages. If we still want to start `jackd` with a script, we can still do that. And this will then just not start jack. @caroline-lin: WDYT?